### PR TITLE
Add HMAC-SHA256 support.

### DIFF
--- a/OfflineLogger/OLManager.h
+++ b/OfflineLogger/OLManager.h
@@ -15,6 +15,7 @@ static NSString *const OLSendingStartedNotification = @"OLSendingStartedNotifica
 static NSString *const OLSendingFinishedNotification = @"OLSendingFinishedNotification";
 
 static NSString *const OLAPIEndpointDefaultsName = @"OLAPIEndpointDefaults";
+static NSString *const OLAPIHMACSignatureKey = @"OLAPIHMACSignatureKey";
 static NSString *const OLLastSentDateDefaultsName = @"OLLastSentDateDefaults";
 static NSString *const OLTrackingStateDefaultsName = @"OLTrackingStateDefaults";
 static NSString *const OLSendIntervalDefaultsName = @"OLSendIntervalDefaults";

--- a/OfflineLogger/OLManager.m
+++ b/OfflineLogger/OLManager.m
@@ -10,6 +10,8 @@
 #import "LOLDatabase.h"
 #import "AFHTTPSessionManager.h"
 
+#import <CommonCrypto/CommonCrypto.h>
+
 @interface OLManager()
 
 @property (strong, nonatomic) CLLocationManager *locationManager;
@@ -60,7 +62,7 @@ AFHTTPSessionManager *_httpClient;
     return _instance;
 }
 
-#pragma mark LOLDB
+#pragma mark - LOLDB
 
 + (NSString *)cacheDatabasePath
 {
@@ -76,6 +78,61 @@ AFHTTPSessionManager *_httpClient;
 + (NSData *)dataWithJSONObject:(id)object error:(NSError **)error;
 {
     return [NSJSONSerialization dataWithJSONObject:object options:0 error:error];
+}
+
+#pragma mark - HMAC
+
+- (NSString*)base64forData:(NSData*)theData
+{
+    // this one is pulled directly off of stack overflow.
+
+    const uint8_t* input = (const uint8_t*)[theData bytes];
+    NSInteger length = [theData length];
+
+    static char table[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
+
+    NSMutableData* data = [NSMutableData dataWithLength:((length + 2) / 3) * 4];
+    uint8_t* output = (uint8_t*)data.mutableBytes;
+
+    NSInteger i;
+    for (i=0; i < length; i += 3) {
+        NSInteger value = 0;
+        NSInteger j;
+        for (j = i; j < (i + 3); j++) {
+            value <<= 8;
+            
+            if (j < length) {
+                value |= (0xFF & input[j]);
+            }
+        }
+        
+        NSInteger theIndex = (i / 3) * 4;
+        output[theIndex + 0] =                    table[(value >> 18) & 0x3F];
+        output[theIndex + 1] =                    table[(value >> 12) & 0x3F];
+        output[theIndex + 2] = (i + 1) < length ? table[(value >> 6)  & 0x3F] : '=';
+        output[theIndex + 3] = (i + 2) < length ? table[(value >> 0)  & 0x3F] : '=';
+    }
+
+    return [[NSString alloc] initWithData:data encoding:NSASCIIStringEncoding];
+}
+
+- (NSString *)computeBase64HMACSignature:(NSString *)serializedArray
+{
+    // serialize the json array into a string
+    NSData* locationsData = [NSJSONSerialization dataWithJSONObject:serializedArray options:0 error:nil];
+    NSString* locationsString = [[NSString alloc] initWithBytes:[locationsData bytes]
+                                                         length:[locationsData length]
+                                                       encoding:NSUTF8StringEncoding];
+    
+    NSString *hmacKey = [[NSUserDefaults standardUserDefaults] objectForKey:OLAPIHMACSignatureKey];
+
+    const char *cKey  = [hmacKey cStringUsingEncoding:NSUTF8StringEncoding];
+    const char *cData = [locationsString cStringUsingEncoding:NSUTF8StringEncoding];
+
+    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA256, cKey, strlen(cKey), cData, strlen(cData), cHMAC);
+    NSData *hmacData = [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+    return [self base64forData:hmacData];
 }
 
 #pragma mark -
@@ -279,7 +336,10 @@ AFHTTPSessionManager *_httpClient;
 
     }];
 
-    NSDictionary *postData = @{@"locations": locationUpdates};
+    NSString *signatureBase64 = [self computeBase64HMACSignature:locationUpdates];
+
+    NSDictionary *postData = @{@"locations": locationUpdates,
+                               @"signature": signatureBase64};
     
     NSString *endpoint = [[NSUserDefaults standardUserDefaults] stringForKey:OLAPIEndpointDefaultsName];
     NSLog(@"Endpoint: %@", endpoint);


### PR DESCRIPTION
There may be a better way to do this, but I implemented the server side first ([reference implementation](https://github.com/rknLA/geo.rkn.la/blob/master/index.js)), and computed the base64 HMAC-SHA256 on a serialized copy of the locations array.

A bunch of the code is copy-paste from stack overflow, but I've verified that the server returns an appropriate error for mismatched keys.
