### PR TITLE
Add url scheme for overland

### DIFF
--- a/GPSLogger/Info.plist
+++ b/GPSLogger/Info.plist
@@ -20,6 +20,19 @@
 	<string>1.2</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>com.aaronpk.overland</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>overland</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>8</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
As discussed in #67 there doesn't seem to be a url scheme, so we wanted to set one up called overland://

This is tied in with changes made for the Siri Shortcuts support but since it's not directly related, I wanted to send it as separate code