### PR TITLE
Fixing Cocopads Configuration

### DIFF
--- a/Overland.xcodeproj/project.pbxproj
+++ b/Overland.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		0FFD317A1BAB7C7F009B3A03 /* libsqlite3.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FFD31761BAB7C7F009B3A03 /* libsqlite3.tbd */; };
 		0FFD317B1BAB7C7F009B3A03 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FFD31771BAB7C7F009B3A03 /* UIKit.framework */; };
 		0FFD317F1BAB7CC7009B3A03 /* LOLDatabase.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FFD317E1BAB7CC7009B3A03 /* LOLDatabase.m */; };
-		6EC056B49F3CF37FAE57EA21 /* libPods-GPSLogger.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3CCE0D26F93B3FCD5A4A1D16 /* libPods-GPSLogger.a */; };
+		F87824B3678FD75F13286822 /* libPods-Overland.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E0A408349E469AC6E6DA46BA /* libPods-Overland.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -64,9 +64,12 @@
 		0FFD31771BAB7C7F009B3A03 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		0FFD317D1BAB7CC7009B3A03 /* LOLDatabase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LOLDatabase.h; sourceTree = "<group>"; };
 		0FFD317E1BAB7CC7009B3A03 /* LOLDatabase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LOLDatabase.m; sourceTree = "<group>"; };
+		251EBCB0197B8F3891607241 /* Pods-Overland.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overland.release.xcconfig"; path = "Pods/Target Support Files/Pods-Overland/Pods-Overland.release.xcconfig"; sourceTree = "<group>"; };
 		378F9BC146097DEF5A9CCBF9 /* Pods-GPSLogger.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GPSLogger.release.xcconfig"; path = "Pods/Target Support Files/Pods-GPSLogger/Pods-GPSLogger.release.xcconfig"; sourceTree = "<group>"; };
 		3CCE0D26F93B3FCD5A4A1D16 /* libPods-GPSLogger.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-GPSLogger.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		4321137E3D59A45E6CD72293 /* Pods-GPSLogger.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-GPSLogger.debug.xcconfig"; path = "Pods/Target Support Files/Pods-GPSLogger/Pods-GPSLogger.debug.xcconfig"; sourceTree = "<group>"; };
+		E0A408349E469AC6E6DA46BA /* libPods-Overland.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Overland.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F4DFFAB32440A8511E1D869A /* Pods-Overland.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Overland.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Overland/Pods-Overland.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,7 +84,7 @@
 				0FFD31791BAB7C7F009B3A03 /* CoreMotion.framework in Frameworks */,
 				0FFD317A1BAB7C7F009B3A03 /* libsqlite3.tbd in Frameworks */,
 				0FFD317B1BAB7C7F009B3A03 /* UIKit.framework in Frameworks */,
-				6EC056B49F3CF37FAE57EA21 /* libPods-GPSLogger.a in Frameworks */,
+				F87824B3678FD75F13286822 /* libPods-Overland.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -100,6 +103,7 @@
 				0FFD31761BAB7C7F009B3A03 /* libsqlite3.tbd */,
 				0FFD31771BAB7C7F009B3A03 /* UIKit.framework */,
 				3CCE0D26F93B3FCD5A4A1D16 /* libPods-GPSLogger.a */,
+				E0A408349E469AC6E6DA46BA /* libPods-Overland.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -182,6 +186,8 @@
 			children = (
 				4321137E3D59A45E6CD72293 /* Pods-GPSLogger.debug.xcconfig */,
 				378F9BC146097DEF5A9CCBF9 /* Pods-GPSLogger.release.xcconfig */,
+				F4DFFAB32440A8511E1D869A /* Pods-Overland.debug.xcconfig */,
+				251EBCB0197B8F3891607241 /* Pods-Overland.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -197,8 +203,6 @@
 				0FFD314E1BAB7A34009B3A03 /* Sources */,
 				0FFD314F1BAB7A34009B3A03 /* Frameworks */,
 				0FFD31501BAB7A34009B3A03 /* Resources */,
-				194409F874597A79AC7202A9 /* [CP] Embed Pods Frameworks */,
-				D263E058FB7FFBE2E9E88DA6 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -267,49 +271,22 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		194409F874597A79AC7202A9 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GPSLogger/Pods-GPSLogger-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
 		42A683883C70BDF3169358D5 /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
 			);
 			name = "[CP] Check Pods Manifest.lock";
 			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Overland-checkManifestLockResult.txt",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
-			showEnvVarsInLog = 0;
-		};
-		D263E058FB7FFBE2E9E88DA6 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-GPSLogger/Pods-GPSLogger-resources.sh\"\n";
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
@@ -432,7 +409,7 @@
 		};
 		0FFD316D1BAB7A34009B3A03 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 4321137E3D59A45E6CD72293 /* Pods-GPSLogger.debug.xcconfig */;
+			baseConfigurationReference = F4DFFAB32440A8511E1D869A /* Pods-Overland.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -448,7 +425,7 @@
 		};
 		0FFD316E1BAB7A34009B3A03 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 378F9BC146097DEF5A9CCBF9 /* Pods-GPSLogger.release.xcconfig */;
+			baseConfigurationReference = 251EBCB0197B8F3891607241 /* Pods-Overland.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";

--- a/Podfile
+++ b/Podfile
@@ -1,8 +1,9 @@
 # Uncomment this line to define a global platform for your project
-# platform :ios, '6.0'
 
-target 'GPSLogger' do
-pod 'AFNetworking'
-pod 'FMDB'
+platform :ios, '11.0'
+
+target 'Overland' do
+	pod 'AFNetworking',		'3.2.1'
+	pod 'FMDB',				'2.7.2'
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,31 +1,36 @@
 PODS:
-  - AFNetworking (3.0.4):
-    - AFNetworking/NSURLSession (= 3.0.4)
-    - AFNetworking/Reachability (= 3.0.4)
-    - AFNetworking/Security (= 3.0.4)
-    - AFNetworking/Serialization (= 3.0.4)
-    - AFNetworking/UIKit (= 3.0.4)
-  - AFNetworking/NSURLSession (3.0.4):
+  - AFNetworking (3.2.1):
+    - AFNetworking/NSURLSession (= 3.2.1)
+    - AFNetworking/Reachability (= 3.2.1)
+    - AFNetworking/Security (= 3.2.1)
+    - AFNetworking/Serialization (= 3.2.1)
+    - AFNetworking/UIKit (= 3.2.1)
+  - AFNetworking/NSURLSession (3.2.1):
     - AFNetworking/Reachability
     - AFNetworking/Security
     - AFNetworking/Serialization
-  - AFNetworking/Reachability (3.0.4)
-  - AFNetworking/Security (3.0.4)
-  - AFNetworking/Serialization (3.0.4)
-  - AFNetworking/UIKit (3.0.4):
+  - AFNetworking/Reachability (3.2.1)
+  - AFNetworking/Security (3.2.1)
+  - AFNetworking/Serialization (3.2.1)
+  - AFNetworking/UIKit (3.2.1):
     - AFNetworking/NSURLSession
-  - FMDB (2.6):
-    - FMDB/standard (= 2.6)
-  - FMDB/standard (2.6)
+  - FMDB (2.7.2):
+    - FMDB/standard (= 2.7.2)
+  - FMDB/standard (2.7.2)
 
 DEPENDENCIES:
-  - AFNetworking
-  - FMDB
+  - AFNetworking (= 3.2.1)
+  - FMDB (= 2.7.2)
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - AFNetworking
+    - FMDB
 
 SPEC CHECKSUMS:
-  AFNetworking: a0075feb321559dc78d9d85b55d11caa19eabb93
-  FMDB: c1968bab3ab0aed38f66cb778ae1e7fa9a652b6e
+  AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
+  FMDB: 6198a90e7b6900cfc046e6bc0ef6ebb7be9236aa
 
-PODFILE CHECKSUM: 2d720709062dd91a1ccea0bf714e3c747d0007fb
+PODFILE CHECKSUM: 6e6a649d028e312855028a64e582180710fd654c
 
-COCOAPODS: 1.2.0
+COCOAPODS: 1.5.3


### PR DESCRIPTION
Ref #69 

This gets the project building again by fixing the Cocoapods target as well as specifies versions for each of the dependencies it's managing.

```sh
// Steps to build project via command line (assumes cocoapods is already installed)

cd Overland-iOS
pod update
open Overland.xcworkspace/
```


/cc @aaronpk 