### PR TITLE
feat: Add support for custom HTTP request headers

### DIFF
--- a/GPSLogger/Base.lproj/Main.storyboard
+++ b/GPSLogger/Base.lproj/Main.storyboard
@@ -1440,8 +1440,19 @@ IAogA
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits" autocorrectionType="no" spellCheckingType="no" returnKeyType="done" smartDashesType="no" smartQuotesType="no"/>
                                     </textField>
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="chb-Hd-R7x">
+                                        <rect key="frame" x="0.0" y="177" width="335" height="34"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="34" id="chb-Ht-C0n"/>
+                                        </constraints>
+                                        <fontDescription key="fontDescription" type="system" pointSize="16"/>
+                                        <state key="normal" title="Custom Headers"/>
+                                        <connections>
+                                            <action selector="customHeadersButtonTapped:" destination="oz3-vM-59N" eventType="touchUpInside" id="chb-Ac-T1n"/>
+                                        </connections>
+                                    </button>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="dhm-5d-E1l">
-                                        <rect key="frame" x="0.0" y="177" width="335" height="30"/>
+                                        <rect key="frame" x="0.0" y="211" width="335" height="30"/>
                                         <state key="normal" title="Save"/>
                                         <connections>
                                             <action selector="saveButtonWasTapped:" destination="oz3-vM-59N" eventType="touchUpInside" id="cGG-Ai-1Y3"/>
@@ -1479,6 +1490,7 @@ For details on the format of the data this app sends to the server, please visit
                     <connections>
                         <outlet property="accessTokenField" destination="Tyk-UF-Fri" id="cCI-D5-30Y"/>
                         <outlet property="apiEndpointField" destination="UKr-2t-LGS" id="TQV-39-goh"/>
+                        <outlet property="customHeadersButton" destination="chb-Hd-R7x" id="chb-Ou-T2p"/>
                         <outlet property="deviceIdField" destination="LDo-Kd-T3a" id="uDX-mW-scj"/>
                     </connections>
                 </viewController>

--- a/GPSLogger/CustomHeadersViewController.h
+++ b/GPSLogger/CustomHeadersViewController.h
@@ -1,0 +1,10 @@
+//
+//  CustomHeadersViewController.h
+//  GPSLogger
+//
+
+#import <UIKit/UIKit.h>
+
+@interface CustomHeadersViewController : UITableViewController
+
+@end

--- a/GPSLogger/CustomHeadersViewController.m
+++ b/GPSLogger/CustomHeadersViewController.m
@@ -1,0 +1,424 @@
+//
+//  CustomHeadersViewController.m
+//  GPSLogger
+//
+
+#import "CustomHeadersViewController.h"
+#import "GLManager.h"
+
+static NSString *const HeaderCellIdentifier  = @"HeaderCell";
+static NSString *const WarningCellIdentifier = @"WarningCell";
+static NSString *const SpacerCellIdentifier  = @"SpacerCell";
+
+#pragma mark - Row model
+
+typedef NS_ENUM(NSInteger, RowType) {
+    RowTypeCard,
+    RowTypeWarning,
+    RowTypeSpacer,
+};
+
+@interface RowItem : NSObject
+@property (nonatomic) RowType type;
+@property (nonatomic) NSInteger headerIndex;
+@property (nonatomic, copy) NSString *warningText;
+@end
+
+@implementation RowItem
++ (instancetype)cardForIndex:(NSInteger)index {
+    RowItem *item = [[RowItem alloc] init];
+    item.type = RowTypeCard;
+    item.headerIndex = index;
+    return item;
+}
++ (instancetype)warningForIndex:(NSInteger)index text:(NSString *)text {
+    RowItem *item = [[RowItem alloc] init];
+    item.type = RowTypeWarning;
+    item.headerIndex = index;
+    item.warningText = text;
+    return item;
+}
++ (instancetype)spacer {
+    RowItem *item = [[RowItem alloc] init];
+    item.type = RowTypeSpacer;
+    item.headerIndex = -1;
+    return item;
+}
+@end
+
+#pragma mark - HeaderTableViewCell
+
+@interface HeaderTableViewCell : UITableViewCell
+
+@property (nonatomic, strong) UIView *cardView;
+@property (nonatomic, strong) UITextField *keyField;
+@property (nonatomic, strong) UITextField *valueField;
+
+@end
+
+@implementation HeaderTableViewCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.backgroundColor = [UIColor clearColor];
+        self.contentView.backgroundColor = [UIColor clearColor];
+
+        _cardView = [[UIView alloc] init];
+        _cardView.backgroundColor = [UIColor secondarySystemGroupedBackgroundColor];
+        _cardView.layer.cornerRadius = 10;
+        _cardView.translatesAutoresizingMaskIntoConstraints = NO;
+
+        _keyField = [[UITextField alloc] init];
+        _keyField.placeholder = @"Header Name";
+        _keyField.font = [UIFont systemFontOfSize:15 weight:UIFontWeightMedium];
+        _keyField.autocorrectionType = UITextAutocorrectionTypeNo;
+        _keyField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        _keyField.spellCheckingType = UITextSpellCheckingTypeNo;
+        _keyField.smartDashesType = UITextSmartDashesTypeNo;
+        _keyField.returnKeyType = UIReturnKeyNext;
+        _keyField.clearButtonMode = UITextFieldViewModeWhileEditing;
+        _keyField.translatesAutoresizingMaskIntoConstraints = NO;
+
+        _valueField = [[UITextField alloc] init];
+        _valueField.placeholder = @"Header Value";
+        _valueField.font = [UIFont systemFontOfSize:15];
+        _valueField.autocorrectionType = UITextAutocorrectionTypeNo;
+        _valueField.autocapitalizationType = UITextAutocapitalizationTypeNone;
+        _valueField.spellCheckingType = UITextSpellCheckingTypeNo;
+        _valueField.smartDashesType = UITextSmartDashesTypeNo;
+        _valueField.returnKeyType = UIReturnKeyDone;
+        _valueField.clearButtonMode = UITextFieldViewModeWhileEditing;
+        _valueField.translatesAutoresizingMaskIntoConstraints = NO;
+
+        UIView *separator = [[UIView alloc] init];
+        separator.backgroundColor = [UIColor separatorColor];
+        separator.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [self.contentView addSubview:_cardView];
+        [_cardView addSubview:_keyField];
+        [_cardView addSubview:separator];
+        [_cardView addSubview:_valueField];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [_cardView.topAnchor constraintEqualToAnchor:self.contentView.topAnchor],
+            [_cardView.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:16],
+            [_cardView.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-16],
+            [_cardView.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
+
+            [_keyField.topAnchor constraintEqualToAnchor:_cardView.topAnchor constant:8],
+            [_keyField.leadingAnchor constraintEqualToAnchor:_cardView.leadingAnchor constant:12],
+            [_keyField.trailingAnchor constraintEqualToAnchor:_cardView.trailingAnchor constant:-12],
+
+            [separator.topAnchor constraintEqualToAnchor:_keyField.bottomAnchor constant:6],
+            [separator.leadingAnchor constraintEqualToAnchor:_cardView.leadingAnchor constant:12],
+            [separator.trailingAnchor constraintEqualToAnchor:_cardView.trailingAnchor constant:-12],
+            [separator.heightAnchor constraintEqualToConstant:0.5],
+
+            [_valueField.topAnchor constraintEqualToAnchor:separator.bottomAnchor constant:6],
+            [_valueField.leadingAnchor constraintEqualToAnchor:_cardView.leadingAnchor constant:12],
+            [_valueField.trailingAnchor constraintEqualToAnchor:_cardView.trailingAnchor constant:-12],
+            [_valueField.bottomAnchor constraintEqualToAnchor:_cardView.bottomAnchor constant:-8],
+        ]];
+    }
+    return self;
+}
+
+@end
+
+#pragma mark - WarningTableViewCell
+
+@interface WarningTableViewCell : UITableViewCell
+
+@property (nonatomic, strong) UILabel *warningLabel;
+
+@end
+
+@implementation WarningTableViewCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.backgroundColor = [UIColor clearColor];
+        self.contentView.backgroundColor = [UIColor clearColor];
+
+        _warningLabel = [[UILabel alloc] init];
+        _warningLabel.font = [UIFont systemFontOfSize:12];
+        _warningLabel.textColor = [UIColor systemRedColor];
+        _warningLabel.numberOfLines = 0;
+        _warningLabel.translatesAutoresizingMaskIntoConstraints = NO;
+
+        [self.contentView addSubview:_warningLabel];
+
+        [NSLayoutConstraint activateConstraints:@[
+            [_warningLabel.topAnchor constraintEqualToAnchor:self.contentView.topAnchor constant:2],
+            [_warningLabel.leadingAnchor constraintEqualToAnchor:self.contentView.leadingAnchor constant:28],
+            [_warningLabel.trailingAnchor constraintEqualToAnchor:self.contentView.trailingAnchor constant:-28],
+            [_warningLabel.bottomAnchor constraintEqualToAnchor:self.contentView.bottomAnchor],
+        ]];
+    }
+    return self;
+}
+
+@end
+
+#pragma mark - SpacerTableViewCell
+
+@interface SpacerTableViewCell : UITableViewCell
+@end
+
+@implementation SpacerTableViewCell
+
+- (instancetype)initWithStyle:(UITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier {
+    self = [super initWithStyle:style reuseIdentifier:reuseIdentifier];
+    if (self) {
+        self.selectionStyle = UITableViewCellSelectionStyleNone;
+        self.backgroundColor = [UIColor clearColor];
+        self.contentView.backgroundColor = [UIColor clearColor];
+    }
+    return self;
+}
+
+@end
+
+#pragma mark - CustomHeadersViewController
+
+@interface CustomHeadersViewController () <UITextFieldDelegate>
+
+@property (nonatomic, strong) NSMutableArray *headers;
+@property (nonatomic, strong) NSArray<RowItem *> *rows;
+@property (nonatomic) BOOL transitioningBetweenFields;
+
+@end
+
+@implementation CustomHeadersViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+
+    self.title = @"Custom Headers";
+    self.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
+
+    self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemAdd
+                                                                                           target:self
+                                                                                           action:@selector(addHeader:)];
+    self.navigationItem.leftBarButtonItem = [[UIBarButtonItem alloc] initWithBarButtonSystemItem:UIBarButtonSystemItemDone
+                                                                                          target:self
+                                                                                          action:@selector(doneButtonTapped:)];
+
+    [self.tableView registerClass:[HeaderTableViewCell class] forCellReuseIdentifier:HeaderCellIdentifier];
+    [self.tableView registerClass:[WarningTableViewCell class] forCellReuseIdentifier:WarningCellIdentifier];
+    [self.tableView registerClass:[SpacerTableViewCell class] forCellReuseIdentifier:SpacerCellIdentifier];
+    self.tableView.separatorStyle = UITableViewCellSeparatorStyleNone;
+    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
+
+    UILabel *footerLabel = [[UILabel alloc] init];
+    footerLabel.text = @"Custom headers are sent with every request to the server.";
+    footerLabel.font = [UIFont systemFontOfSize:12];
+    footerLabel.textColor = [UIColor tertiaryLabelColor];
+    footerLabel.textAlignment = NSTextAlignmentCenter;
+    footerLabel.numberOfLines = 0;
+    footerLabel.frame = CGRectMake(0, 0, 0, 30);
+    self.tableView.tableFooterView = footerLabel;
+
+    self.headers = [[[GLManager sharedManager] customHeaders] mutableCopy];
+    [self rebuildRows];
+}
+
+- (void)rebuildRows {
+    NSMutableArray<RowItem *> *items = [NSMutableArray array];
+    for (NSInteger i = 0; i < (NSInteger)self.headers.count; i++) {
+        if (i > 0) {
+            [items addObject:[RowItem spacer]];
+        }
+        [items addObject:[RowItem cardForIndex:i]];
+        NSString *warning = [self warningForHeaderIndex:i];
+        if (warning) {
+            [items addObject:[RowItem warningForIndex:i text:warning]];
+        }
+    }
+    self.rows = [items copy];
+}
+
+#pragma mark - Table view data source
+
+- (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView {
+    return 1;
+}
+
+- (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
+    if (self.headers.count == 0) {
+        UILabel *label = [[UILabel alloc] init];
+        label.text = @"No custom headers.\nTap + to add one.";
+        label.numberOfLines = 0;
+        label.textAlignment = NSTextAlignmentCenter;
+        label.textColor = [UIColor secondaryLabelColor];
+        label.font = [UIFont systemFontOfSize:15];
+        self.tableView.backgroundView = label;
+    } else {
+        self.tableView.backgroundView = nil;
+    }
+    return self.rows.count;
+}
+
+- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath {
+    RowItem *item = self.rows[indexPath.row];
+    if (item.type == RowTypeSpacer) {
+        return 6;
+    }
+    return UITableViewAutomaticDimension;
+}
+
+- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
+    RowItem *item = self.rows[indexPath.row];
+
+    if (item.type == RowTypeCard) {
+        HeaderTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:HeaderCellIdentifier forIndexPath:indexPath];
+        NSDictionary *header = self.headers[item.headerIndex];
+
+        cell.keyField.text = header[@"key"];
+        cell.valueField.text = header[@"value"];
+
+        cell.keyField.delegate = self;
+        cell.valueField.delegate = self;
+
+        NSString *warning = [self warningForHeaderIndex:item.headerIndex];
+        cell.keyField.textColor = warning ? [UIColor systemRedColor] : [UIColor labelColor];
+
+        return cell;
+    } else if (item.type == RowTypeWarning) {
+        WarningTableViewCell *cell = [tableView dequeueReusableCellWithIdentifier:WarningCellIdentifier forIndexPath:indexPath];
+        cell.warningLabel.text = item.warningText;
+        return cell;
+    } else {
+        return [tableView dequeueReusableCellWithIdentifier:SpacerCellIdentifier forIndexPath:indexPath];
+    }
+}
+
+- (BOOL)tableView:(UITableView *)tableView canEditRowAtIndexPath:(NSIndexPath *)indexPath {
+    RowItem *item = self.rows[indexPath.row];
+    return item.type == RowTypeCard;
+}
+
+- (void)tableView:(UITableView *)tableView commitEditingStyle:(UITableViewCellEditingStyle)editingStyle forRowAtIndexPath:(NSIndexPath *)indexPath {
+    if (editingStyle == UITableViewCellEditingStyleDelete) {
+        RowItem *item = self.rows[indexPath.row];
+        [self.headers removeObjectAtIndex:item.headerIndex];
+        [self saveHeaders];
+        [self rebuildRows];
+        [self.tableView reloadData];
+    }
+}
+
+#pragma mark - UITextFieldDelegate
+
+- (void)textFieldDidEndEditing:(UITextField *)textField {
+    HeaderTableViewCell *cell = (HeaderTableViewCell *)[self cellForTextField:textField];
+    if (cell == nil) return;
+
+    NSIndexPath *indexPath = [self.tableView indexPathForCell:cell];
+    if (indexPath == nil) return;
+
+    RowItem *item = self.rows[indexPath.row];
+    if (item.headerIndex >= (NSInteger)self.headers.count) return;
+
+    NSString *key = cell.keyField.text ?: @"";
+    NSString *value = cell.valueField.text ?: @"";
+
+    self.headers[item.headerIndex] = @{@"key": key, @"value": value};
+    [self saveHeaders];
+
+    if (!self.transitioningBetweenFields) {
+        [self rebuildRows];
+        [self.tableView reloadData];
+    }
+}
+
+- (BOOL)textFieldShouldReturn:(UITextField *)textField {
+    HeaderTableViewCell *cell = (HeaderTableViewCell *)[self cellForTextField:textField];
+    if (cell == nil) return YES;
+
+    if (textField == cell.keyField) {
+        self.transitioningBetweenFields = YES;
+        [cell.valueField becomeFirstResponder];
+        self.transitioningBetweenFields = NO;
+    } else {
+        [textField resignFirstResponder];
+    }
+    return YES;
+}
+
+- (UITableViewCell *)cellForTextField:(UITextField *)textField {
+    UIView *view = textField.superview;
+    while (view != nil && ![view isKindOfClass:[UITableViewCell class]]) {
+        view = view.superview;
+    }
+    return (UITableViewCell *)view;
+}
+
+#pragma mark - Validation
+
+- (NSString *)warningForHeaderIndex:(NSInteger)index {
+    if (index >= (NSInteger)self.headers.count) return nil;
+
+    NSString *key = self.headers[index][@"key"];
+    if (key.length == 0) return nil;
+
+    if ([key caseInsensitiveCompare:@"Authorization"] == NSOrderedSame) {
+        return @"Use the Access Token field for authorization. This header will not be sent.";
+    }
+
+    for (NSInteger i = 0; i < (NSInteger)self.headers.count; i++) {
+        if (i == index) continue;
+        NSString *otherKey = self.headers[i][@"key"];
+        if (otherKey.length > 0 && [key caseInsensitiveCompare:otherKey] == NSOrderedSame) {
+            return @"Duplicate header name. This may cause unexpected behavior.";
+        }
+    }
+
+    return nil;
+}
+
+#pragma mark - Actions
+
+- (void)addHeader:(id)sender {
+    [self.view endEditing:YES];
+
+    [self.headers addObject:@{@"key": @"", @"value": @""}];
+    [self rebuildRows];
+    [self.tableView reloadData];
+
+    NSInteger newHeaderIndex = self.headers.count - 1;
+    for (NSInteger i = 0; i < (NSInteger)self.rows.count; i++) {
+        RowItem *item = self.rows[i];
+        if (item.type == RowTypeCard && item.headerIndex == newHeaderIndex) {
+            NSIndexPath *path = [NSIndexPath indexPathForRow:i inSection:0];
+            [self.tableView scrollToRowAtIndexPath:path atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.3 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                HeaderTableViewCell *cell = [self.tableView cellForRowAtIndexPath:path];
+                [cell.keyField becomeFirstResponder];
+            });
+            break;
+        }
+    }
+}
+
+- (void)saveHeaders {
+    NSMutableArray *nonEmpty = [NSMutableArray array];
+    for (NSDictionary *header in self.headers) {
+        if ([header[@"key"] length] > 0 && [header[@"value"] length] > 0) {
+            [nonEmpty addObject:header];
+        }
+    }
+    [[GLManager sharedManager] saveCustomHeaders:[nonEmpty copy]];
+}
+
+- (void)doneButtonTapped:(id)sender {
+    [self.view endEditing:YES];
+    [self saveHeaders];
+    [self dismissViewControllerAnimated:YES completion:nil];
+}
+
+@end

--- a/GPSLogger/EndpointViewController.h
+++ b/GPSLogger/EndpointViewController.h
@@ -13,7 +13,9 @@
 @property (strong, nonatomic) IBOutlet UITextField *apiEndpointField;
 @property (strong, nonatomic) IBOutlet UITextField *accessTokenField;
 @property (strong, nonatomic) IBOutlet UITextField *deviceIdField;
+@property (strong, nonatomic) IBOutlet UIButton *customHeadersButton;
 
 - (IBAction)saveButtonWasTapped:(UIButton *)sender;
+- (IBAction)customHeadersButtonTapped:(UIButton *)sender;
 
 @end

--- a/GPSLogger/EndpointViewController.m
+++ b/GPSLogger/EndpointViewController.m
@@ -8,6 +8,7 @@
 
 #import "EndpointViewController.h"
 #import "GLManager.h"
+#import "CustomHeadersViewController.h"
 
 @interface EndpointViewController ()
 
@@ -20,6 +21,31 @@
     self.accessTokenField.text = [GLManager sharedManager].apiAccessToken;
     self.deviceIdField.text = [GLManager sharedManager].deviceId;
     self.apiEndpointField.backgroundColor = [UIColor clearColor];
+
+    self.customHeadersButton.backgroundColor = [self.customHeadersButton.tintColor colorWithAlphaComponent:0.12];
+    self.customHeadersButton.layer.cornerRadius = 8;
+    self.customHeadersButton.clipsToBounds = YES;
+
+    [self updateCustomHeadersButtonTitle];
+
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(updateCustomHeadersButtonTitle)
+                                                 name:GLSettingsChangedNotification
+                                               object:nil];
+}
+
+- (void)viewWillDisappear:(BOOL)animated {
+    [super viewWillDisappear:animated];
+    [[NSNotificationCenter defaultCenter] removeObserver:self name:GLSettingsChangedNotification object:nil];
+}
+
+- (void)updateCustomHeadersButtonTitle {
+    NSArray *headers = [[GLManager sharedManager] customHeaders];
+    if (headers.count > 0) {
+        [self.customHeadersButton setTitle:[NSString stringWithFormat:@"Custom Headers (%lu)", (unsigned long)headers.count] forState:UIControlStateNormal];
+    } else {
+        [self.customHeadersButton setTitle:@"Custom Headers" forState:UIControlStateNormal];
+    }
 }
 
 - (IBAction)saveButtonWasTapped:(UIButton *)sender {
@@ -45,6 +71,17 @@
     } else {
         self.apiEndpointField.backgroundColor = [UIColor colorWithRed:1.0 green:0.82 blue:0.82 alpha:1.0];
     }
+}
+
+- (IBAction)customHeadersButtonTapped:(UIButton *)sender {
+    CustomHeadersViewController *vc = [[CustomHeadersViewController alloc] initWithStyle:UITableViewStylePlain];
+    UINavigationController *nav = [[UINavigationController alloc] initWithRootViewController:vc];
+    [self presentViewController:nav animated:YES completion:nil];
+}
+
+- (void)viewDidAppear:(BOOL)animated {
+    [super viewDidAppear:animated];
+    [self updateCustomHeadersButtonTitle];
 }
 
 @end

--- a/GPSLogger/GLManager.h
+++ b/GPSLogger/GLManager.h
@@ -41,6 +41,7 @@ static NSString *const GLBackgroundIndicatorDefaultsName = @"GLBackgroundIndicat
 static NSString *const GLLoggingModeDefaultsName = @"GLLoggingModeDefaults";
 static NSString *const GLTripModeStatsDefaultsName = @"GLTripModeStats";
 static NSString *const GLVisitTrackingEnabledDefaultsName = @"GLVisitTrackingEnabledDefaults";
+static NSString *const GLCustomHeadersDefaultsName = @"GLCustomHeadersDefaults";
 
 static NSString *const GLPurgeQueueOnNextLaunchDefaultsName = @"GLPurgeQueueOnNextLaunch";
 static NSString *const GLLastScheduledNotificationDateDefaultsName = @"GLLastScheduledNotificationDateDefaults";
@@ -161,6 +162,9 @@ typedef void (^CaseBlock)(void);
 - (NSString *)apiAccessToken;
 - (void)saveNewDeviceId:(NSString *)deviceId;
 - (NSString *)deviceId;
+
+- (NSArray *)customHeaders;
+- (void)saveCustomHeaders:(NSArray *)headers;
 
 - (void)logAction:(NSString *)action;
 - (void)sendQueueNow;

--- a/GPSLogger/GLManager.m
+++ b/GPSLogger/GLManager.m
@@ -114,6 +114,20 @@ const double MPH_to_METERSPERSECOND = 0.447;
     return d;
 }
 
+- (NSArray *)customHeaders {
+    NSArray *headers = [[NSUserDefaults standardUserDefaults] arrayForKey:GLCustomHeadersDefaultsName];
+    if (headers == nil) {
+        return @[];
+    }
+    return headers;
+}
+
+- (void)saveCustomHeaders:(NSArray *)headers {
+    [[NSUserDefaults standardUserDefaults] setObject:headers forKey:GLCustomHeadersDefaultsName];
+    [self setupHTTPClient];
+    [[NSNotificationCenter defaultCenter] postNotificationName:GLSettingsChangedNotification object:self];
+}
+
 - (void)startAllUpdates {
     [self enableTracking];
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:GLTrackingStateDefaultsName];
@@ -481,7 +495,18 @@ const double MPH_to_METERSPERSECOND = 0.447;
         [self runBlock:minTimeDuringTripBlocks fromDictionary:trip forKey:@"min_time"];
 
     }
-    
+
+    NSDictionary *customHeadersDict = [settings objectForKey:@"custom_headers"];
+    if (customHeadersDict != nil && [customHeadersDict respondsToSelector:@selector(enumerateKeysAndObjectsUsingBlock:)]) {
+        NSMutableArray *headers = [NSMutableArray array];
+        [customHeadersDict enumerateKeysAndObjectsUsingBlock:^(id key, id value, BOOL *stop) {
+            if ([key isKindOfClass:[NSString class]] && [value isKindOfClass:[NSString class]]) {
+                [headers addObject:@{@"key": key, @"value": value}];
+            }
+        }];
+        [self saveCustomHeaders:headers];
+    }
+
     [[NSNotificationCenter defaultCenter] postNotificationName:GLSettingsChangedNotification object:self];
 }
 
@@ -630,8 +655,19 @@ const double MPH_to_METERSPERSECOND = 0.447;
         } else {
             [_httpClient.requestSerializer setValue:nil forHTTPHeaderField:@"Authorization"];
         }
+
+        // Apply custom headers
+        NSArray *customHeaders = [self customHeaders];
+        for (NSDictionary *header in customHeaders) {
+            NSString *key = header[@"key"];
+            NSString *value = header[@"value"];
+            if (key.length > 0 && value.length > 0
+                && [key caseInsensitiveCompare:@"Authorization"] != NSOrderedSame) {
+                [_httpClient.requestSerializer setValue:value forHTTPHeaderField:key];
+            }
+        }
     }
-    
+
     _deviceId = [self deviceId];
 }
 

--- a/GPSLogger/SceneDelegate.m
+++ b/GPSLogger/SceneDelegate.m
@@ -66,6 +66,18 @@
         [[GLManager sharedManager] saveNewDeviceId:deviceId];
         [[GLManager sharedManager] saveNewAPIEndpoint:endpoint andAccessToken:token];
         [[NSUserDefaults standardUserDefaults] setBool:[uniqueId isEqualToString:@"yes"] forKey:GLIncludeUniqueIdDefaultsName];
+        NSMutableArray *customHeaders = [NSMutableArray array];
+        for (NSURLQueryItem *item in queryItems) {
+            if ([item.name hasPrefix:@"header_"]) {
+                NSString *headerKey = [item.name substringFromIndex:7];
+                if (headerKey.length > 0 && item.value.length > 0) {
+                    [customHeaders addObject:@{@"key": headerKey, @"value": item.value}];
+                }
+            }
+        }
+        if (customHeaders.count > 0) {
+            [[GLManager sharedManager] saveCustomHeaders:customHeaders];
+        }
     }
 }
 

--- a/Overland.xcodeproj/project.pbxproj
+++ b/Overland.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		0FAC1FEB2B255CA60007F3B1 /* NSArray+map.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAC1FEA2B255CA60007F3B1 /* NSArray+map.m */; };
 		0FAC1FEE2B25FBB50007F3B1 /* SceneDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FAC1FED2B25FBB50007F3B1 /* SceneDelegate.m */; };
 		0FB85AC01BE0151800F25126 /* ExternalAccessory.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FB85ABF1BE0151800F25126 /* ExternalAccessory.framework */; };
+		0FC4E00A2D0B000000000001 /* CustomHeadersViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FC4E00A2D0B000000000003 /* CustomHeadersViewController.m */; };
 		0FCF53251F81AB0800577A0F /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0FCF53241F81AB0800577A0F /* UserNotifications.framework */; };
 		0FCF532E1F83FDBC00577A0F /* EndpointViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 0FCF532D1F83FDBC00577A0F /* EndpointViewController.m */; };
 		0FE280B12B0180620062936E /* Settings.bundle in Resources */ = {isa = PBXBuildFile; fileRef = 0FE280B02B0180620062936E /* Settings.bundle */; };
@@ -56,6 +57,8 @@
 		0FAC1FEF2B25FBC10007F3B1 /* SceneDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SceneDelegate.h; sourceTree = "<group>"; };
 		0FB85ABD1BE0151300F25126 /* CoreBluetooth.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreBluetooth.framework; path = System/Library/Frameworks/CoreBluetooth.framework; sourceTree = SDKROOT; };
 		0FB85ABF1BE0151800F25126 /* ExternalAccessory.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ExternalAccessory.framework; path = System/Library/Frameworks/ExternalAccessory.framework; sourceTree = SDKROOT; };
+		0FC4E00A2D0B000000000002 /* CustomHeadersViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CustomHeadersViewController.h; sourceTree = "<group>"; };
+		0FC4E00A2D0B000000000003 /* CustomHeadersViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CustomHeadersViewController.m; sourceTree = "<group>"; };
 		0FCF53231F81AAAC00577A0F /* GPSLogger.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = GPSLogger.entitlements; sourceTree = "<group>"; };
 		0FCF53241F81AB0800577A0F /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		0FCF532C1F83FDBC00577A0F /* EndpointViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = EndpointViewController.h; sourceTree = "<group>"; };
@@ -181,6 +184,8 @@
 				0FF5902F2B1FA1D500E3AAA3 /* TripSettingsViewController.m */,
 				0FCF532C1F83FDBC00577A0F /* EndpointViewController.h */,
 				0FCF532D1F83FDBC00577A0F /* EndpointViewController.m */,
+				0FC4E00A2D0B000000000002 /* CustomHeadersViewController.h */,
+				0FC4E00A2D0B000000000003 /* CustomHeadersViewController.m */,
 				6D2858CF222B133400F525E1 /* WifiZoneViewController.h */,
 				6D2858D0222B133400F525E1 /* WifiZoneViewController.m */,
 				0FABDE382B329448003ACD20 /* TipJarViewController.h */,
@@ -347,6 +352,7 @@
 				0FAC1FEB2B255CA60007F3B1 /* NSArray+map.m in Sources */,
 				0FFD31731BAB7BEA009B3A03 /* GLManager.m in Sources */,
 				0FCF532E1F83FDBC00577A0F /* EndpointViewController.m in Sources */,
+				0FC4E00A2D0B000000000001 /* CustomHeadersViewController.m in Sources */,
 				0F444F0C1BD04A7E00106C2E /* TripModeViewController.m in Sources */,
 				0FAC1FEE2B25FBB50007F3B1 /* SceneDelegate.m in Sources */,
 				0FFD315D1BAB7A34009B3A03 /* TrackingViewController.m in Sources */,


### PR DESCRIPTION
Adds a configurable list of custom HTTP headers (key/value pairs) to the Server URL settings, sent with every outgoing request alongside the existing Bearer token.

This enables usage behind reverse proxies and zero-trust solutions (e.g. Cloudflare Access) that require additional headers for authentication.

Closes:
- #189