### PR TITLE
Update Android link to Colota

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ The app sends data to an HTTP endpoint. You can use an existing backend or build
 * [Icecondor](https://icecondor.com/) - a service for tracking your location, sharing with friends, and setting geofence alerts
 * [Home Assistant](https://www.home-assistant.io/) - home automation platform, compatible with the [OwnTracks](https://www.home-assistant.io/integrations/owntracks/) format supported by Home Assistant
 
-Looking for the Android version? → https://github.com/OpenHumans/overland_android
+Looking for the Android version? → [Colota](https://github.com/dietrichmax/colota) ([Overland integration](https://colota.app/docs/integrations/overland))
+
 
 ## Documentation
 


### PR DESCRIPTION
Hi! You mentioned once you would list Colota as Android alternative if it supports the same payload. Well, it does now. Updated the README accordingly. Replaced the existing link to the repo because the OpenHumans overland_android app seems delisted from the Play Store (404).