### PR TITLE
Add Geomanic to the list of compatible servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ The app sends data to an HTTP endpoint. You can use an existing backend or build
 * [PureTrack](https://puretrack.io/add-overland) - a service for tracking lightweight planes and gliders
 * [Open Humans](https://overland.openhumans.org/) - a service for tracking your data and sharing it for research purposes
 * [Icecondor](https://icecondor.com/) - a service for tracking your location, sharing with friends, and setting geofence alerts
+* [Geomanic](https://geomanic.com/) - a free hosted service for tracking your trips, with country statistics, travel analytics, and tax residency day counts
 * [Home Assistant](https://www.home-assistant.io/) - home automation platform, compatible with the [OwnTracks](https://www.home-assistant.io/integrations/owntracks/) format supported by Home Assistant
 
 Looking for the Android version? → https://github.com/OpenHumans/overland_android


### PR DESCRIPTION
This adds [Geomanic](https://geomanic.com/) to the "works with" list.

Geomanic is a free, GDPR-compliant hosted service that natively supports the Overland receiver format (POST with a `locations` array of GeoJSON features). Users get per-country day statistics (full/part days), travel analytics (distance, speed, altitude), GPX/GeoJSON import/export, and backups.

There is a step-by-step setup guide for Overland users: https://geomanic.com/guides/overland-setup

No affiliation with the Overland project — just adding a compatible backend, same as the other entries in the list.